### PR TITLE
Correction bug formulaire creation docs de vente

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -731,7 +731,7 @@ jQuery(document).ready(function() {
     	      			{
     	      				// If margin is calculated on PMP, we set it by defaut (but only if value is not 0)
     			      		//console.log("id="+this.id+"-price="+this.price);
-    			      		if ('pmp' == defaultbuyprice || 'costprice' == defaultbuyprice)
+    			      		if ('pmp' == defaultbuyprice)
     			      		{
     			      			if (this.price > 0) {
     				      			defaultkey = this.id; defaultprice = this.price; pmppriceid = this.id; pmppricevalue = this.price;


### PR DESCRIPTION
Correction pour prendre en compte le chois dans le module marge, sinon c'est toujours le PMP qui est proposé par défaut au lieu de la methode de marge selectionnée dans le modules marges.

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "Fix", "Close" or "New" section*
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed textswith meaningful informations*


# Fix #[*issue_number Short description*]
[*Long description*]


# Close #[*issue_number Short description*]
[*Long description*]


# New [*Short description*]
[*Long description*]
